### PR TITLE
fix(editor): fix issue where removing a property from component would not update editor state

### DIFF
--- a/packages/editor-core/src/reducer/reducer.ts
+++ b/packages/editor-core/src/reducer/reducer.ts
@@ -19,7 +19,6 @@ const reducer = (state: any, action: any) => {
 		return { ...state };
 	case 'UPDATE_PROPS':
 		state.components[action.id] = {
-			...state.components[action.id],
 			...action.props
 		};
 		return { ...state };


### PR DESCRIPTION
update `UPDATE_PROPS` reducer logic to stop merging previous component state in order to allow new state to contain fewer object keys than previous state (allow deleting of component prop)