### PR TITLE
fix(editor): fix issue where drag and drop would break after updating component

### DIFF
--- a/packages/editor-core/src/reducer/reducer.ts
+++ b/packages/editor-core/src/reducer/reducer.ts
@@ -19,7 +19,8 @@ const reducer = (state: any, action: any) => {
 		return { ...state };
 	case 'UPDATE_PROPS':
 		state.components[action.id] = {
-			...action.props
+			...action.props,
+			ref: state.components[action.id].ref
 		};
 		return { ...state };
 	case 'REMOVE_COMPONENT':


### PR DESCRIPTION
preserve `ref` property when `UPDATE_PROPS` reducer is run so that `dnd` can still find the target element