### PR TITLE
Wrap `text-field` with `Autocomplete` to provide a way to add text suggestions

### DIFF
--- a/packages/evergreen-component-mapper/src/text-field/text-field.tsx
+++ b/packages/evergreen-component-mapper/src/text-field/text-field.tsx
@@ -7,15 +7,15 @@ import { UseFieldApiProps } from '@data-driven-forms/react-form-renderer';
 
 export interface TextFieldProps extends UseFieldApiProps<string> {
 	name: string;
-	items: string[];
+	items?: string[];
 	isRequired?: boolean;
 }
 
 const TextField: React.FC<TextFieldProps> = (props) => {
-	const { input, meta, isRequired, items, ...rest } = useFieldApi(props);
+	const { input, meta, isRequired, items, ...rest } = useFieldApi(props) as TextFieldProps;
 
 	return (
-		<Autocomplete {...input} items={items} {...rest}>
+		<Autocomplete {...input} items={items || []}>
 			{({ getInputProps, getRef, inputValue, openMenu }) => (
 				<TextInputField
 					ref={getRef}
@@ -24,6 +24,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 					validationMessage={meta.error}
 					{...getInputProps({ onFocus: () => openMenu() })}
 					value={inputValue}
+					{...rest}
 				/>
 			)}
 		</Autocomplete>

--- a/packages/evergreen-component-mapper/src/text-field/text-field.tsx
+++ b/packages/evergreen-component-mapper/src/text-field/text-field.tsx
@@ -1,25 +1,33 @@
 import React from 'react';
 
-import { TextInputField } from 'evergreen-ui';
+import { Autocomplete, TextInputField } from 'evergreen-ui';
 
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import { UseFieldApiProps } from '@data-driven-forms/react-form-renderer';
 
 export interface TextFieldProps extends UseFieldApiProps<string> {
-    name: string;
-    isRequired?: boolean;
-};
+	name: string;
+	items: string[];
+	isRequired?: boolean;
+}
 
 const TextField: React.FC<TextFieldProps> = (props) => {
-	const { input, meta, isRequired, ...rest } = useFieldApi(props);
+	const { input, meta, isRequired, items, ...rest } = useFieldApi(props);
 
-	return <TextInputField
-		{...input}
-		required={isRequired}
-		isInvalid={Boolean(meta.error)}
-		validationMessage={meta.error}
-		{...rest}
-	/>;
+	return (
+		<Autocomplete {...input} items={items} {...rest}>
+			{({ getInputProps, getRef, inputValue, openMenu }) => (
+				<TextInputField
+					ref={getRef}
+					required={isRequired}
+					isInvalid={Boolean(meta.error)}
+					validationMessage={meta.error}
+					{...getInputProps({ onFocus: () => openMenu() })}
+					value={inputValue}
+				/>
+			)}
+		</Autocomplete>
+	);
 };
 
 export default TextField;


### PR DESCRIPTION
Wrapping the Evergreen `TextInputField` component in the `text-field.tsx` component with the Evergreen `Autocomplete` component and adding the `items` prop for adding text suggestions that would show up as the user types into the field.

By allowing text suggestions, we are able to add contextual suggestions for the given input. Doing so would greatly improve the end-user experience as it provides them with guided input.