### PR TITLE
fix(Components): 🐛 Fix the issue with not being able to use other values with `TextField` when `items` was provided.

### DIFF
--- a/packages/evergreen-component-mapper/src/text-field/text-field.tsx
+++ b/packages/evergreen-component-mapper/src/text-field/text-field.tsx
@@ -15,7 +15,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 	const { input, meta, isRequired, items, ...rest } = useFieldApi(props) as TextFieldProps;
 
 	return (
-		<Autocomplete {...input} items={items || []}>
+		<Autocomplete {...input} items={items || []} allowOtherValues>
 			{({ getInputProps, getRef, inputValue, openMenu }) => (
 				<TextInputField
 					ref={getRef}


### PR DESCRIPTION
Currently, with the recent merge of this PR: https://github.com/data-driven-forms/editor/pull/25, while providing the `text-field` component with the `items` prop does work as expected (provides proper suggestions), other custom input values do not get set whatsoever.

Adding this `allowOtherValues` prop to the `Autocomplete` component fixes this issue.
Evergreen Reference: https://evergreen.segment.com/components/autocomplete/props